### PR TITLE
CFG_IN_TREE_EARLY_TAS += trusted_keys/f04a0fe7-1f5d-4b9b-abf7-619b85b…

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -284,6 +284,7 @@ $(call force,CFG_TZC380,n)
 $(call force,CFG_NXP_CAAM,n)
 CFG_IMX_MU ?= y
 CFG_IMX_ELE ?= y
+CFG_IN_TREE_EARLY_TAS += trusted_keys/f04a0fe7-1f5d-4b9b-abf7-619b85b4ce8c
 else
 $(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")
 endif


### PR DESCRIPTION
This pull request adds a new early Trusted Application (TA) to the build configuration for the i.MX ARM platform. The change ensures that the TA identified by `trusted_keys/f04a0fe7-1f5d-4b9b-abf7-619b85b4ce8c` is included in the `CFG_IN_TREE_EARLY_TAS` variable, which controls which TAs are built into the image early in the boot process. It was there for imx93 but not for imx91

Trusted Application inclusion:

* Updated `core/arch/arm/plat-imx/conf.mk` to include the new TA `trusted_keys/f04a0fe7-1f5d-4b9b-abf7-619b85b4ce8c` in the `CFG_IN_TREE_EARLY_TAS` variable, ensuring it is available during early boot.…4ce8c

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
